### PR TITLE
Removed forbidden characters from problem names

### DIFF
--- a/main.py
+++ b/main.py
@@ -67,6 +67,7 @@ for submission in submissions:
     new_directory = base_dir + '/' + str(con_id)
     if not os.path.exists(new_directory):
         os.makedirs(new_directory)
+    prob_name = re.sub(r'[\\/*?:"<>|]',"", prob_name)
     file = open(new_directory + '/' + prob_id + ' [' + prob_name + ']' + '.' + ext, 'w')
     file.write(result)
     file.close()

--- a/main.py
+++ b/main.py
@@ -68,7 +68,7 @@ for submission in submissions:
     if not os.path.exists(new_directory):
         os.makedirs(new_directory)
     prob_name = re.sub(r'[\\/*?:"<>|]',"", prob_name)
-    file = open(new_directory + '/' + prob_id + ' [' + prob_name + ']' + '.' + ext, 'w')
+    file = open(new_directory + '/' + prob_id + ' [' + prob_name.encode('utf-8') + ']' + '.' + ext, 'w')
     file.write(result)
     file.close()
 end_time = time.time()

--- a/main.py
+++ b/main.py
@@ -69,7 +69,7 @@ for submission in submissions:
         os.makedirs(new_directory)
     prob_name = re.sub(r'[\\/*?:"<>|]',"", prob_name)
     file = open(new_directory + '/' + prob_id + ' [' + prob_name.encode('utf-8') + ']' + '.' + ext, 'w')
-    file.write(result)
+    file.write(result.encode('utf-8'))
     file.close()
 end_time = time.time()
 


### PR DESCRIPTION
Errors occured because of invalid characters filenames from problem names like "Valid BFS ?" problem
used re.sub to fix the problem's name